### PR TITLE
Bump lib version, also upgrades 2 deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, nightly, 1.41.0]
+        rust: [stable, nightly, 1.46.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "Readme.md"
 license = "MIT"
 
 [dependencies]
-bitcoin = "0.26"
+bitcoin = "0.27"
 structopt = "0.3.21"
 log = "0.4.11"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 bitcoin = "0.27"
 structopt = "0.3.21"
 log = "0.4.11"
-env_logger = "0.7"
+env_logger = "0.9"
 glob = "0.3.0"
 fxhash = "0.2.1"
 rayon = { version = "1.5.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blocks_iterator"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 edition = "2018"
 description = "Iterates Bitcoin blocks"


### PR DESCRIPTION
MSRV upgraded to 1.46 because some dep broke the compatibility (bitflags, I think) and for some reason I can't pin it and I lost patience (will revisit if someone needs MSRV lower)