### PR TITLE
refactor: make `ReadDetect` into a resource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,11 +135,8 @@ pub fn iterate(config: Config, channel: SyncSender<Option<BlockExtra>>) -> JoinH
 
         // FsBlock is a small struct (~120b), so 10_000 is not a problem but allows the read_detect to read ahead the next block file
         let (send_block_fs, receive_block_fs) = sync_channel(0);
-        let mut read =
+        let _read =
             read_detect::ReadDetect::new(config.blocks_dir.clone(), config.network, send_block_fs);
-        let read_handle = thread::spawn(move || {
-            read.start();
-        });
 
         let (send_ordered_blocks, receive_ordered_blocks) =
             sync_channel(config.channels_size.into());
@@ -167,7 +164,6 @@ pub fn iterate(config: Config, channel: SyncSender<Option<BlockExtra>>) -> JoinH
             fee_handle.join().unwrap();
         }
 
-        read_handle.join().unwrap();
         orderer_handle.join().unwrap();
         info!("Total time elapsed: {}s", now.elapsed().as_secs());
     })


### PR DESCRIPTION
This is to show the pattern I always use for threads
in Rust. Feel free to ignore if you don't like it.

`ReadDetect` represents a thread/worker. Creating it
starts it, eliminating the need for the caller to bother handling
anything about it. (There's really no point in creating the `ReadDetect`
without starting it).

The returned value is a real handle. It will join automatically
on a drop (methods could be added to change that behavior if desired).

There's a little bit of right drift as the `start` was inlined,
but it could be refactored out into a static function if desired.