### PR TITLE
Improve logging in main executable

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,12 +1,12 @@
 #![allow(non_snake_case)]
 
 use blocks_iterator::Config;
+use blocks_iterator::PeriodCounter;
 use env_logger::Env;
 use log::info;
 use std::error::Error;
 use std::sync::mpsc::sync_channel;
 use std::time::Duration;
-use std::time::Instant;
 use structopt::StructOpt;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -16,36 +16,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let config = Config::from_args();
     let (send, recv) = sync_channel(config.channels_size.into());
     let handle = blocks_iterator::iterate(config, send);
+    let mut bench = PeriodCounter::new(Duration::from_secs(1));
 
-    let start = Instant::now();
-    let mut last = Instant::now();
-    let mut blocks = 0;
-    let mut txs = 0;
-    let mut blocks_total = 0;
-    let mut txs_total = 0;
     while let Some(item) = recv.recv()? {
-        blocks += 1;
-        blocks_total += 1;
-        txs += item.block.txdata.len() as u64;
-        txs_total += item.block.txdata.len() as u64;
+        bench.count_block(&item.block);
 
-        let now = Instant::now();
-        let period = Duration::from_secs(1);
-        let current_duration = now.duration_since(last);
-
-        if current_duration >= period {
-            let total_duration = now.duration_since(start);
-            eprintln!(
-                "Current: {:>5} blk/s; {:>6} txs/s; Total: {:>5} blk/s; {:>6} tx/s;",
-                blocks / current_duration.as_secs(),
-                txs / current_duration.as_secs(),
-                blocks_total / total_duration.as_secs(),
-                txs_total / total_duration.as_secs(),
-            );
-
-            last = now;
-            txs = 0;
-            blocks = 0;
+        if let Some(stats) = bench.period_elapsed() {
+            info!("{}", stats);
         }
     }
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,84 @@
+use bitcoin::Block;
+use std::fmt;
+use std::fmt::Formatter;
+use std::time::Duration;
+use std::time::Instant;
+
+/// Contains counter and instants to provide per period stats over transaction and blocks processed
+#[derive(Debug)]
+pub struct PeriodCounter {
+    start: Instant,
+    last: Instant,
+    stats: Stats,
+    period: Duration,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Stats {
+    current: BlocksTxs,
+    total: BlocksTxs,
+}
+
+#[derive(Debug, Default, Clone)]
+struct BlocksTxs {
+    blocks: u64,
+    txs: u64,
+    period: Duration,
+}
+
+impl BlocksTxs {
+    fn blocks(&self) -> u64 {
+        ((self.blocks as u128 * 1000u128) / self.period.as_millis()) as u64
+    }
+    fn txs(&self) -> u64 {
+        ((self.txs as u128 * 1000u128) / self.period.as_millis()) as u64
+    }
+}
+
+impl PeriodCounter {
+    /// Create a [`PeriodCounter`] with given `period`
+    pub fn new(period: Duration) -> Self {
+        PeriodCounter {
+            start: Instant::now(),
+            last: Instant::now(),
+            stats: Default::default(),
+            period,
+        }
+    }
+
+    /// Count statistics of the given block
+    pub fn count_block(&mut self, block: &Block) {
+        self.stats.current.blocks += 1;
+        self.stats.current.txs += block.txdata.len() as u64;
+
+        self.stats.total.blocks += 1;
+        self.stats.total.txs += block.txdata.len() as u64;
+    }
+
+    /// If `self.period` has passed since last invocation return stats
+    pub fn period_elapsed(&mut self) -> Option<Stats> {
+        if self.last.elapsed() >= self.period {
+            self.stats.total.period = self.start.elapsed();
+            self.stats.current.period = self.last.elapsed();
+            let return_value = self.stats.clone();
+            self.stats.current = BlocksTxs::default();
+            self.last = Instant::now();
+            Some(return_value)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for Stats {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Current: {:>5} blk/s; {:>6} txs/s; Total: {:>5} blk/s; {:>6} tx/s;",
+            self.current.blocks(),
+            self.current.txs(),
+            self.total.blocks(),
+            self.total.txs()
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use structopt::StructOpt;
 use utxo::AnyUtxo;
 
@@ -165,11 +165,34 @@ pub fn iterate(config: Config, channel: SyncSender<Option<BlockExtra>>) -> JoinH
 }
 
 /// Utility method usually returning [log::Level::Debug] but when `i` is divisible by `every` returns [log::Level::Info]
+#[deprecated]
 pub fn periodic_log_level(i: u32, every: u32) -> Level {
     if i % every == 0 {
         Level::Info
     } else {
         Level::Debug
+    }
+}
+
+/// Utility used to return true after `period`
+pub struct Periodic {
+    last: Instant,
+    period: Duration,
+}
+impl Periodic {
+    fn new(period: Duration) -> Self {
+        Periodic {
+            last: Instant::now(),
+            period,
+        }
+    }
+    fn elapsed(&mut self) -> bool {
+        if self.last.elapsed() > self.period {
+            self.last = Instant::now();
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ use std::time::Instant;
 use structopt::StructOpt;
 use utxo::AnyUtxo;
 
+pub use bench::PeriodCounter;
+
+mod bench;
 mod block_extra;
 mod fee;
 mod pipe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,15 @@ use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use structopt::StructOpt;
 use utxo::AnyUtxo;
 
-pub use bench::PeriodCounter;
+pub use period::{PeriodCounter, Periodic};
 
-mod bench;
 mod block_extra;
 mod fee;
+mod period;
 mod pipe;
 mod read_detect;
 mod reorder;
@@ -171,28 +171,6 @@ pub fn periodic_log_level(i: u32, every: u32) -> Level {
         Level::Info
     } else {
         Level::Debug
-    }
-}
-
-/// Utility used to return true after `period`
-pub struct Periodic {
-    last: Instant,
-    period: Duration,
-}
-impl Periodic {
-    fn new(period: Duration) -> Self {
-        Periodic {
-            last: Instant::now(),
-            period,
-        }
-    }
-    fn elapsed(&mut self) -> bool {
-        if self.last.elapsed() > self.period {
-            self.last = Instant::now();
-            true
-        } else {
-            false
-        }
     }
 }
 

--- a/src/period.rs
+++ b/src/period.rs
@@ -82,3 +82,27 @@ impl fmt::Display for Stats {
         )
     }
 }
+
+/// Utility used to return true after `period`
+pub struct Periodic {
+    last: Instant,
+    period: Duration,
+}
+impl Periodic {
+    /// Create [`Periodic`]
+    pub fn new(period: Duration) -> Self {
+        Periodic {
+            last: Instant::now(),
+            period,
+        }
+    }
+    /// Returns `true` if `self.period` elapsed from last time
+    pub fn elapsed(&mut self) -> bool {
+        if self.last.elapsed() > self.period {
+            self.last = Instant::now();
+            true
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
Include blocks and transactions per second like bench example

use period based on seconds instead of height for periodic logging

close #32 