### PR TITLE
bump version to 0.12.1, change state parameter in par_iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Release 0.12.1 - 2022-04-23
+
+### Changed
+
+- `blocks_iterator::par_iter` accepts an `Arc<STATE>` instead of a `STATE` so it can be used after
+  the call
+
 ## Release 0.12.0 - 2022-04-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blocks_iterator"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 edition = "2018"
 description = "Iterates Bitcoin blocks"

--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -64,9 +64,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let config = Config::from_args();
 
-    let state = AtomicUsize::new(0);
+    let state = Arc::new(AtomicUsize::new(0));
 
-    blocks_iterator::par_iter(config, state, pre_processing, task);
+    blocks_iterator::par_iter(config, state.clone(), pre_processing, task);
+
+    info!("error count: {}", state.load(Ordering::SeqCst));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub fn iter(config: Config) -> impl Iterator<Item = BlockExtra> {
 ///  
 pub fn par_iter<STATE, PREPROC, TASK, DATA>(
     config: Config,
-    state: STATE,
+    state: Arc<STATE>,
     pre_processing: PREPROC,
     task: TASK,
 ) where
@@ -206,7 +206,6 @@ pub fn par_iter<STATE, PREPROC, TASK, DATA>(
 
     let (send_task, recv_task) = sync_channel(config.channels_size.into());
     let stop = Arc::new(AtomicBool::new(false));
-    let state = Arc::new(state);
 
     let stop_clone = stop.clone();
     let iter = iter(config);


### PR DESCRIPTION
while technically a breaking change in par_iter method, since 0.12.0 has
just been released a minor release is done.