### PR TITLE
Block extra new format, pre compute txids

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [ "verify --features consensus,parallel", "signatures_in_witness", "outputs_versions"]
+        example: [ "verify --features consensus", "signatures_in_witness", "outputs_versions"]
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = "0.10.2", optional = true, features = ["asm"] }
 # only for verify example
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
 
-rayon = { version = "1.5.0", optional = true }
+rayon = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
@@ -36,7 +36,6 @@ tempfile = "3.2.0"
 [features]
 default = ["db", "consensus"]
 db = ["rocksdb", "rand"]
-parallel = ["rayon"]
 consensus = ["bitcoinconsensus", "bitcoin/bitcoinconsensus"]
 unstable = ["sha2", "blake3"]
 
@@ -48,7 +47,7 @@ name = "most_output_pipe"
 
 [[example]]
 name = "verify"
-required-features = ["consensus","parallel"]
+required-features = ["consensus"]
 
 [[example]]
 name = "signatures_in_witness"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ blake3 = { version = "1.0.0", optional = true }
 sha2 = { version = "0.10.2", optional = true, features = ["asm"] }
 
 # only for verify example
-bitcoinconsensus = { version = "0.19.0-3", optional = true }
+#bitcoinconsensus = { version = "0.19.0-4", optional = true }
+bitcoinconsensus = { git = "https://github.com/rust-bitcoin/rust-bitcoinconsensus", rev="b00bd5089384d5b653de1ff5fb1feb613500e50e", optional = true }
 
 rayon = "1.5.0"
 
@@ -54,6 +55,3 @@ name = "signatures_in_witness"
 
 [[example]]
 name = "outputs_versions"
-
-[patch.crates-io]
-bitcoinconsensus = { git ="https://github.com/RCasatta/rust-bitcoinconsensus", rev="12a909866d5346fc79e3c068f3c15bee1e3e7342" }

--- a/examples/heaviest_pipe.rs
+++ b/examples/heaviest_pipe.rs
@@ -14,11 +14,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let iter = PipeIterator::new(io::stdin(), Some(io::stdout()));
 
     for block_extra in iter {
-        for tx in block_extra.block.txdata.iter() {
+        for (txid, tx) in block_extra.iter_tx() {
             if tx.weight() > heaviest.1 {
-                let txid = tx.txid();
                 info!("New heaviest tx: {}", txid);
-                heaviest = (txid, tx.weight());
+                heaviest = (*txid, tx.weight());
             }
         }
     }

--- a/examples/most_output_pipe.rs
+++ b/examples/most_output_pipe.rs
@@ -14,11 +14,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let iter = PipeIterator::new(io::stdin(), Some(io::stdout()));
 
     for block_extra in iter {
-        for tx in block_extra.block.txdata.iter() {
+        for (txid, tx) in block_extra.iter_tx() {
             if tx.output.len() > most_output.1 {
-                let txid = tx.txid();
                 info!("New most_output tx: {}", txid);
-                most_output = (txid, tx.output.len());
+                most_output = (*txid, tx.output.len());
             }
         }
     }

--- a/examples/outputs_versions.rs
+++ b/examples/outputs_versions.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             info!("taproot locked in");
         }
 
-        for tx in block_extra.block.txdata {
+        for (txid, tx) in block_extra.iter_tx() {
             for (i, output) in tx.output.iter().enumerate() {
                 if output.script_pubkey.is_witness_program() {
                     let mut version = output.script_pubkey.as_bytes()[0] as usize;
@@ -45,10 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     if version >= 1 {
                         let log_line = format!(
                             "tx:{} output:{} version:{} height:{}",
-                            tx.txid(),
-                            i,
-                            version,
-                            block_extra.height
+                            txid, i, version, block_extra.height
                         );
                         info!("{}", log_line);
                         output_file.write(log_line.as_bytes()).unwrap();

--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -6,7 +6,6 @@ use env_logger::Env;
 use log::{debug, error, info};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::error::Error;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use structopt::StructOpt;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -49,7 +49,6 @@ pub fn iter(config: Config) -> impl Iterator<Item = BlockExtra> {
     note = "you can get better and composable results by concateneting method on iter like 
     blocks_iterator::iter(config).flat_map(PREPROC).par_bridge().for_each(TASK)"
 )]
-#[cfg(feature = "parallel")]
 /// `par_iter` is used when the task to be performed on the blockchain is more costly
 /// than iterating the blocks. For example verifying the spending conditions in the blockchain.
 /// like [`crate::iter`] accepts configuration parameters via the [`Config`] struct.

--- a/src/stages/compute_txids.rs
+++ b/src/stages/compute_txids.rs
@@ -1,0 +1,61 @@
+use crate::BlockExtra;
+use log::info;
+use rayon::prelude::*;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::SyncSender;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use std::time::Instant;
+
+pub struct ComputeTxids {
+    join: Option<JoinHandle<()>>,
+}
+
+impl Drop for ComputeTxids {
+    fn drop(&mut self) {
+        if let Some(jh) = self.join.take() {
+            jh.join().expect("thread failed");
+        }
+    }
+}
+
+impl ComputeTxids {
+    pub fn new(
+        receiver: Receiver<Option<BlockExtra>>,
+        sender: SyncSender<Option<BlockExtra>>,
+    ) -> Self {
+        Self {
+            join: Some(std::thread::spawn(move || {
+                info!("starting augment processer");
+                let mut now = Instant::now();
+                let mut busy_time = Duration::default();
+                loop {
+                    busy_time += now.elapsed();
+                    let received = receiver.recv().unwrap();
+                    now = Instant::now();
+                    match received {
+                        Some(mut block_extra) => {
+                            block_extra.compute_txids();
+                            busy_time += now.elapsed();
+                            sender.send(Some(block_extra)).unwrap();
+                            now = Instant::now();
+                        }
+                        None => break,
+                    }
+                }
+                info!("ending augment processer busy time: {:?}", busy_time,);
+                sender.send(None).expect("augment: cannot send none");
+            })),
+        }
+    }
+}
+
+impl BlockExtra {
+    fn compute_txids(&mut self) {
+        if !self.txids.is_empty() {
+            return;
+        }
+
+        self.txids = self.block.txdata.par_iter().map(|tx| tx.txid()).collect();
+    }
+}

--- a/src/stages/fee.rs
+++ b/src/stages/fee.rs
@@ -45,7 +45,7 @@ impl Fee {
                             total_txs += block_extra.block.txdata.len() as u64;
 
                             let mut prevouts =
-                                utxo.add_outputs_get_inputs(&block_extra.block, block_extra.height);
+                                utxo.add_outputs_get_inputs(&block_extra, block_extra.height);
                             let mut prevouts = prevouts.drain(..);
 
                             for tx in block_extra.block.txdata.iter().skip(1) {

--- a/src/stages/mod.rs
+++ b/src/stages/mod.rs
@@ -1,7 +1,9 @@
+mod compute_txids;
 mod fee;
 mod read_detect;
 mod reorder;
 
+pub use compute_txids::ComputeTxids;
 pub use fee::Fee;
 pub use read_detect::ReadDetect;
 pub use reorder::Reorder;

--- a/src/stages/read_detect.rs
+++ b/src/stages/read_detect.rs
@@ -69,6 +69,8 @@ impl ReadDetect {
         let mut periodic = Periodic::new(Duration::from_secs(60));
         Self {
             join: Some(std::thread::spawn(move || {
+                info!("starting read_detect");
+
                 let mut now = Instant::now();
                 let mut seen = Seen::new();
                 let mut path = blocks_dir.clone();
@@ -112,10 +114,11 @@ impl ReadDetect {
                     now = Instant::now();
                 }
                 info!(
-                    "ending reader parse , busy time: {}s",
+                    "ending read_detect , busy time: {}s",
                     (busy_time / 1_000_000_000)
                 );
                 if !early_stop.load(Ordering::Relaxed) {
+                    info!("sending None");
                     sender.send(None).expect("cannot send");
                 }
             })),

--- a/src/stages/reorder.rs
+++ b/src/stages/reorder.rs
@@ -106,6 +106,8 @@ impl Reorder {
         let mut periodic = Periodic::new(Duration::from_secs(60));
         Self {
             join: Some(std::thread::spawn(move || {
+                info!("starting reorder");
+
                 let mut bench = PeriodCounter::new(Duration::from_secs(10));
 
                 let mut busy_time = 0u128;
@@ -114,6 +116,8 @@ impl Reorder {
                 loop {
                     busy_time += now.elapsed().as_nanos();
                     let received = receiver.recv().unwrap_or_default();
+                    info!("reorder receive {:?}", received.as_ref().map(|e| e.len()));
+
                     now = Instant::now();
                     match received {
                         Some(raw_blocks) => {

--- a/src/stages/reorder.rs
+++ b/src/stages/reorder.rs
@@ -116,7 +116,6 @@ impl Reorder {
                 loop {
                     busy_time += now.elapsed().as_nanos();
                     let received = receiver.recv().unwrap_or_default();
-                    info!("reorder receive {:?}", received.as_ref().map(|e| e.len()));
 
                     now = Instant::now();
                     match received {

--- a/src/utxo/mod.rs
+++ b/src/utxo/mod.rs
@@ -1,4 +1,4 @@
-use crate::bitcoin::{Block, TxOut};
+use crate::{bitcoin::TxOut, BlockExtra};
 
 mod mem;
 
@@ -16,7 +16,7 @@ pub trait UtxoStore {
     /// Return all the prevouts in the block at `height` in the order they are found in the block.
     /// First element in the vector is the prevout of the first input of the first transaction after
     /// the coinbase
-    fn add_outputs_get_inputs(&mut self, block: &Block, height: u32) -> Vec<TxOut>;
+    fn add_outputs_get_inputs(&mut self, block_extra: &BlockExtra, height: u32) -> Vec<TxOut>;
 
     /// return stats about the Utxo
     fn stat(&self) -> String;
@@ -33,11 +33,11 @@ pub enum AnyUtxo {
 }
 
 impl UtxoStore for AnyUtxo {
-    fn add_outputs_get_inputs(&mut self, block: &Block, height: u32) -> Vec<TxOut> {
+    fn add_outputs_get_inputs(&mut self, block_extra: &BlockExtra, height: u32) -> Vec<TxOut> {
         match self {
             #[cfg(feature = "db")]
-            AnyUtxo::Db(db) => db.add_outputs_get_inputs(block, height),
-            AnyUtxo::Mem(mem) => mem.add_outputs_get_inputs(block, height),
+            AnyUtxo::Db(db) => db.add_outputs_get_inputs(block_extra, height),
+            AnyUtxo::Mem(mem) => mem.add_outputs_get_inputs(block_extra, height),
         }
     }
 


### PR DESCRIPTION
close #52 #53

bring significant speed up!

Speed up is most noticeable in the memory case and in the first run of the db case. When the db has cached values no txid computation is done up to the last processed height so no significant improvement if the last processed height is near the current height. However, downstream consumer almost always compute txids, and now they have it pre-cached so improvement is present also there.