### PR TITLE
test consensus_encode with &mut, updated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bitcoin =  { version = "0.28.0", features = ["use-serde"]}
+# bitcoin =  { version = "0.28.0", features = ["use-serde"]}
+bitcoin =  { git="https://github.com/dpc/rust-bitcoin", rev="1fea098dfb916d64f2ecbfb9a13b8d264020bc1e", features = ["serde"]}
+#  -rwxrwxr-x   2 casatta casatta 13736992 Jun  9 14:04 blocks_iterator
 structopt = "0.3.21"
 log = "0.4.11"
 glob = "0.3.0"
@@ -34,10 +36,14 @@ rayon = "1.5.0"
 tempfile = "3.2.0"
 
 [features]
-default = ["db", "consensus"]
+default = []
 db = ["rocksdb", "rand"]
 consensus = ["bitcoinconsensus", "bitcoin/bitcoinconsensus"]
 unstable = ["sha2", "blake3"]
+
+[[bin]]
+name = "blocks_iterator"
+required-features = ["db"]
 
 [[example]]
 name = "heaviest_pipe"

--- a/examples/signatures_in_witness.rs
+++ b/examples/signatures_in_witness.rs
@@ -61,25 +61,25 @@ struct ParsedSignature {
 }
 
 impl Decodable for ParsedSignature {
-    fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: std::io::Read + ?Sized>(d: &mut D) -> Result<Self, encode::Error> {
         //TODO fix for schnorr signatures!
-        let first = u8::consensus_decode(&mut d)?;
+        let first = u8::consensus_decode(d)?;
         if first != 0x30 {
             return Err(encode::Error::ParseFailed("Signature must start with 0x30"));
         }
-        let _ = u8::consensus_decode(&mut d)?;
-        let integer_header = u8::consensus_decode(&mut d)?;
+        let _ = u8::consensus_decode(d)?;
+        let integer_header = u8::consensus_decode(d)?;
         if integer_header != 0x02 {
             return Err(encode::Error::ParseFailed("No integer header"));
         }
 
-        let R = <Vec<u8>>::consensus_decode(&mut d)?;
-        let integer_header = u8::consensus_decode(&mut d)?;
+        let R = <Vec<u8>>::consensus_decode(d)?;
+        let integer_header = u8::consensus_decode(d)?;
         if integer_header != 0x02 {
             return Err(encode::Error::ParseFailed("No integer header"));
         }
-        let s = <Vec<u8>>::consensus_decode(&mut d)?;
-        let sighash_u8 = u8::consensus_decode(&mut d)?;
+        let s = <Vec<u8>>::consensus_decode(d)?;
+        let sighash_u8 = u8::consensus_decode(d)?;
         let sighash = EcdsaSighashType::from_consensus(sighash_u8 as u32);
 
         Ok(ParsedSignature {

--- a/src/block_extra.rs
+++ b/src/block_extra.rs
@@ -49,8 +49,9 @@ impl TryFrom<FsBlock> for BlockExtra {
         file.seek(SeekFrom::Start(fs_block.start as u64))
             .map_err(|e| err(e.to_string(), &fs_block))?;
         debug!("going to read: {:?}", file);
-        let reader = BufReader::new(file);
-        let block = Block::consensus_decode(reader).map_err(|e| err(e.to_string(), &fs_block))?;
+        let mut reader = BufReader::new(file);
+        let block =
+            Block::consensus_decode(&mut reader).map_err(|e| err(e.to_string(), &fs_block))?;
 
         let txs = &block.txdata;
         let block_total_inputs = txs.iter().fold(0usize, |acc, tx| acc + tx.input.len());
@@ -110,56 +111,56 @@ impl BlockExtra {
 }
 
 impl Encodable for BlockExtra {
-    fn consensus_encode<W: Write>(&self, mut writer: W) -> Result<usize, std::io::Error> {
+    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let mut written = 0;
-        written += self.version.consensus_encode(&mut writer)?;
-        written += self.block.consensus_encode(&mut writer)?;
-        written += self.block_hash.consensus_encode(&mut writer)?;
-        written += self.size.consensus_encode(&mut writer)?;
-        written += self.next.consensus_encode(&mut writer)?;
-        written += self.height.consensus_encode(&mut writer)?;
-        written += (self.outpoint_values.len() as u32).consensus_encode(&mut writer)?;
+        written += self.version.consensus_encode(writer)?;
+        written += self.block.consensus_encode(writer)?;
+        written += self.block_hash.consensus_encode(writer)?;
+        written += self.size.consensus_encode(writer)?;
+        written += self.next.consensus_encode(writer)?;
+        written += self.height.consensus_encode(writer)?;
+        written += (self.outpoint_values.len() as u32).consensus_encode(writer)?;
         for (out_point, tx_out) in self.outpoint_values.iter() {
-            written += out_point.consensus_encode(&mut writer)?;
-            written += tx_out.consensus_encode(&mut writer)?;
+            written += out_point.consensus_encode(writer)?;
+            written += tx_out.consensus_encode(writer)?;
         }
-        written += self.block_total_inputs.consensus_encode(&mut writer)?;
-        written += self.block_total_outputs.consensus_encode(&mut writer)?;
-        written += (self.txids.len() as u32).consensus_encode(&mut writer)?;
+        written += self.block_total_inputs.consensus_encode(writer)?;
+        written += self.block_total_outputs.consensus_encode(writer)?;
+        written += (self.txids.len() as u32).consensus_encode(writer)?;
         for txid in self.txids.iter() {
-            written += txid.consensus_encode(&mut writer)?;
+            written += txid.consensus_encode(writer)?;
         }
         Ok(written)
     }
 }
 
 impl Decodable for BlockExtra {
-    fn consensus_decode<D: Read>(mut d: D) -> Result<Self, encode::Error> {
+    fn consensus_decode<D: Read + ?Sized>(d: &mut D) -> Result<Self, encode::Error> {
         Ok(BlockExtra {
-            version: Decodable::consensus_decode(&mut d)?,
-            block: Decodable::consensus_decode(&mut d)?,
-            block_hash: Decodable::consensus_decode(&mut d)?,
-            size: Decodable::consensus_decode(&mut d)?,
-            next: Decodable::consensus_decode(&mut d)?,
-            height: Decodable::consensus_decode(&mut d)?,
+            version: Decodable::consensus_decode(d)?,
+            block: Decodable::consensus_decode(d)?,
+            block_hash: Decodable::consensus_decode(d)?,
+            size: Decodable::consensus_decode(d)?,
+            next: Decodable::consensus_decode(d)?,
+            height: Decodable::consensus_decode(d)?,
             outpoint_values: {
-                let len = u32::consensus_decode(&mut d)?;
+                let len = u32::consensus_decode(d)?;
                 let mut m = HashMap::with_capacity(len as usize);
                 for _ in 0..len {
                     m.insert(
-                        Decodable::consensus_decode(&mut d)?,
-                        Decodable::consensus_decode(&mut d)?,
+                        Decodable::consensus_decode(d)?,
+                        Decodable::consensus_decode(d)?,
                     );
                 }
                 m
             },
-            block_total_inputs: Decodable::consensus_decode(&mut d)?,
-            block_total_outputs: Decodable::consensus_decode(&mut d)?,
+            block_total_inputs: Decodable::consensus_decode(d)?,
+            block_total_outputs: Decodable::consensus_decode(d)?,
             txids: {
-                let len = u32::consensus_decode(&mut d)?;
+                let len = u32::consensus_decode(d)?;
                 let mut v = Vec::with_capacity(len as usize);
                 for _ in 0..len {
-                    v.push(Decodable::consensus_decode(&mut d)?);
+                    v.push(Decodable::consensus_decode(d)?);
                 }
                 v
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let blocks_iter = blocks_iterator::iter(config);
     let mut buffer = [0u8; MAX_VEC_SIZE];
     for block_extra in blocks_iter {
-        let size = block_extra.consensus_encode(&mut buffer[..]).unwrap();
+        let size = block_extra.consensus_encode(&mut &mut buffer[..]).unwrap();
         io::stdout().write_all(&buffer[..size])?;
     }
     info!("end");

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -38,7 +38,9 @@ impl Iterator for PipeIterator {
         if let Some(stdout) = self.stdout.as_mut() {
             // using StreamReader we can't send received bytes directly to stdout, thus we need to
             // re-serialize back
-            let len = block_extra.consensus_encode(&mut self.buffer[..]).unwrap(); // buffer is big enough, we can unwrap
+            let len = block_extra
+                .consensus_encode(&mut &mut self.buffer[..])
+                .unwrap(); // buffer is big enough, we can unwrap
             stdout.write_all(&self.buffer[..len]).unwrap();
         }
 

--- a/src/utxo/db.rs
+++ b/src/utxo/db.rs
@@ -48,17 +48,17 @@ impl DbUtxo {
 
 fn serialize_outpoint(o: &OutPoint, buffer: &mut [u8; 37]) {
     buffer[0] = UTXO_PREFIX;
-    o.consensus_encode(&mut buffer[1..]).unwrap();
+    o.consensus_encode(&mut &mut buffer[1..]).unwrap();
 }
 
 fn serialize_txout(o: &TxOut, buffer: &mut [u8; 10_011]) -> usize {
     // No need to prefix, used
-    o.consensus_encode(&mut buffer[..]).unwrap()
+    o.consensus_encode(&mut &mut buffer[..]).unwrap()
 }
 
 fn serialize_prevouts_height(h: i32) -> [u8; 5] {
     let mut ser = [PREVOUTS_PREFIX, 0, 0, 0, 0];
-    h.consensus_encode(&mut ser[1..]).unwrap();
+    h.consensus_encode(&mut &mut ser[1..]).unwrap();
     ser
 }
 


### PR DESCRIPTION
supercede #56 