### PR TITLE
NOTWORKING: use cfg bench instead of feature unstable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           command: test
           args: --verbose --no-default-features
-      - run: cargo +nightly bench --features unstable --no-default-features
+      - run: RUSTFLAGS='--cfg=bench' cargo +nightly bench --no-default-features
         if: ${{ matrix.rust == 'nightly' }}
 
   examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,6 @@ env_logger = "0.9"
 rand = { version = "0.8.4", optional = true }
 rocksdb = { version = "0.18.0", optional = true, default-features = false }
 
-# only for benching
-blake3 = { version = "1.0.0", optional = true }
-sha2 = { version = "0.10.2", optional = true, features = ["asm"] }
-
 # only for verify example
 bitcoinconsensus = { version = "0.19.0-0.4.0", optional = true }
 
@@ -32,12 +28,14 @@ rayon = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
+blake3 = "1.0.0"
+sha2 = { version = "0.10.2",  features = ["asm"] }
+
 
 [features]
 default = ["db", "consensus"]
 db = ["rocksdb", "rand"]
 consensus = ["bitcoinconsensus", "bitcoin/bitcoinconsensus"]
-unstable = ["sha2", "blake3"]
 
 [[example]]
 name = "heaviest_pipe"

--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ The `1.0` is not to be intended as *battle-tested production-ready* library, the
 ## MSRV 
 
 Check minimum rust version run in CI (as of May 2022 is `1.56.1`)
+
+### Running benchmarks
+
+We use a custom Rust compiler configuration conditional to guard the bench mark code. To run the
+bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![deny(unused_must_use)]
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
-#[cfg(all(test, feature = "unstable"))]
+#![cfg_attr(bench, feature(test))]
+
+#[cfg(bench)]
 extern crate test;
 
 use bitcoin::BlockHash;
@@ -278,7 +279,7 @@ mod inner_test {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod bench {
     use crate::bitcoin::hashes::{sha256, Hash, HashEngine};
     use crate::bitcoin::OutPoint;

--- a/src/utxo/db.rs
+++ b/src/utxo/db.rs
@@ -178,7 +178,7 @@ mod test {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod bench {
 
     use rocksdb::{Options, WriteBatch, DB};


### PR DESCRIPTION
attempt to fix #58 

```
:~/git/blocks_iterator(cfg_bench)$ RUSTFLAGS='--cfg=bench' cargo +nightly bench
   Compiling blocks_iterator v1.0.0 (/home/casatta/git/blocks_iterator)
error[E0432]: unresolved import `sha2`
   --> src/lib.rs:287:9
    |
287 |     use sha2::{Digest, Sha256};
    |         ^^^^ use of undeclared crate or module `sha2`

error: unused imports: `DB`, `Options`, `WriteBatch`
   --> src/utxo/db.rs:184:19
    |
184 |     use rocksdb::{Options, WriteBatch, DB};
    |                   ^^^^^^^  ^^^^^^^^^^  ^^
    |
note: the lint level is defined here
   --> src/lib.rs:18:9
    |
18  | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^

error: unused import: `test::Bencher`
   --> src/utxo/db.rs:185:9
    |
185 |     use test::Bencher;
    |         ^^^^^^^^^^^^^

error: unused imports: `HashEngine`, `Hash`, `sha256`
   --> src/lib.rs:284:34
    |
284 |     use crate::bitcoin::hashes::{sha256, Hash, HashEngine};
    |                                  ^^^^^^  ^^^^  ^^^^^^^^^^

error: unused import: `crate::bitcoin::OutPoint`
   --> src/lib.rs:285:9
    |
285 |     use crate::bitcoin::OutPoint;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

error: unused import: `bitcoin::hashes::sha256::Midstate`
   --> src/lib.rs:286:9
    |
286 |     use bitcoin::hashes::sha256::Midstate;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unused imports: `Bencher`, `black_box`
   --> src/lib.rs:288:16
    |
288 |     use test::{black_box, Bencher};
    |                ^^^^^^^^^  ^^^^^^^

For more information about this error, try `rustc --explain E0432`.
```