### PR TITLE
remove rocksdb, use redb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,8 @@ log = "0.4.11"
 glob = "0.3.0"
 fxhash = "0.2.1"
 env_logger = "0.9"
-bitcoin_slices = { version="0.4", features = ["sha2"] }
-
-rand = { version = "0.8.4", optional = true }
-rocksdb = { version = "0.18.0", optional = true, default-features = false }
+#bitcoin_slices = { version="0.4", features = ["sha2"] }
+bitcoin_slices = { path="../bitcoin_slices", features = ["sha2", "redb"] }
 
 # only for benching
 blake3 = { version = "1.0.0", optional = true }
@@ -36,13 +34,11 @@ tempfile = "3.2.0"
 
 [features]
 default = []
-db = ["rocksdb", "rand"]
 consensus = ["bitcoinconsensus", "bitcoin/bitcoinconsensus"]
 unstable = ["sha2", "blake3"]
 
 [[bin]]
 name = "blocks_iterator"
-required-features = ["db"]
 
 [[example]]
 name = "with_pipe"

--- a/src/bsl.rs
+++ b/src/bsl.rs
@@ -25,11 +25,11 @@ impl<'a> Visit<'a> for BlockExtra<'a> {
         let block_size = U32::parse(block_hash.remaining())?;
         consumed += 32;
 
-        let next_len = bsl::Len::parse(block_size.remaining())?;
+        let next_len = bsl::parse_len(block_size.remaining())?;
         consumed += next_len.consumed();
 
-        let mut current = next_len.remaining();
-        for _ in 0..next_len.parsed().n() {
+        let mut current = &block_size.remaining()[consumed..];
+        for _ in 0..next_len.n() {
             let block_hash = read_slice(current, 32)?;
             current = block_hash.remaining();
             consumed += 32;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -124,7 +124,6 @@ mod inner_test {
             skip_prevout: false,
             max_reorg: 10,
             channels_size: 0,
-            #[cfg(feature = "db")]
             utxo_db: None,
             start_at_height: 0,
             stop_at_height: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@ pub struct Config {
     #[structopt(short, long, default_value = "0")]
     pub channels_size: u8,
 
-    #[cfg(feature = "db")]
     /// Specify a directory where a database will be created to store the Utxo (when `--skip-prevout` is not used)
     /// Reduce the memory requirements but it's slower and use disk space
     #[structopt(short, long)]
@@ -104,11 +103,6 @@ pub struct Config {
 }
 
 impl Config {
-    #[cfg(not(feature = "db"))]
-    fn utxo_manager(&self) -> AnyUtxo {
-        AnyUtxo::Mem(utxo::MemUtxo::new(self.network))
-    }
-    #[cfg(feature = "db")]
     fn utxo_manager(&self) -> AnyUtxo {
         match &self.utxo_db {
             Some(path) => AnyUtxo::Db(utxo::DbUtxo::new(path).unwrap()), //TODO unwrap
@@ -225,7 +219,6 @@ mod inner_test {
             skip_prevout: false,
             max_reorg: 10,
             channels_size: 0,
-            #[cfg(feature = "db")]
             utxo_db: None,
             start_at_height: 0,
             stop_at_height: None,
@@ -248,7 +241,6 @@ mod inner_test {
         handle.join().unwrap();
     }
 
-    #[cfg(feature = "db")]
     #[test]
     fn test_blk_testnet_db() {
         let _ = env_logger::try_init();

--- a/src/utxo/mod.rs
+++ b/src/utxo/mod.rs
@@ -1,14 +1,11 @@
 use crate::{bitcoin::TxOut, BlockExtra};
 
-mod mem;
-
-#[cfg(feature = "db")]
 mod db;
+mod mem;
 
 pub use mem::MemUtxo;
 
 use bitcoin::OutPoint;
-#[cfg(feature = "db")]
 pub use db::DbUtxo;
 
 pub trait UtxoStore {
@@ -27,7 +24,6 @@ trait Hash64 {
 }
 
 pub enum AnyUtxo {
-    #[cfg(feature = "db")]
     Db(db::DbUtxo),
     Mem(MemUtxo),
 }
@@ -35,7 +31,6 @@ pub enum AnyUtxo {
 impl UtxoStore for AnyUtxo {
     fn add_outputs_get_inputs(&mut self, block_extra: &BlockExtra, height: u32) -> Vec<TxOut> {
         match self {
-            #[cfg(feature = "db")]
             AnyUtxo::Db(db) => db.add_outputs_get_inputs(block_extra, height),
             AnyUtxo::Mem(mem) => mem.add_outputs_get_inputs(block_extra, height),
         }
@@ -43,7 +38,6 @@ impl UtxoStore for AnyUtxo {
 
     fn stat(&self) -> String {
         match self {
-            #[cfg(feature = "db")]
             AnyUtxo::Db(db) => db.stat(),
             AnyUtxo::Mem(mem) => mem.stat(),
         }


### PR DESCRIPTION
Unfortunately redb `batch_write` is much slower than rocksdb, I still like more redb because it doesn't take a life to compile and it's more typed.
Probably adding redb without a feature and keeping feature gated rocksdb?


```
testnet stop @100_000 tmpfs                                                     
                                                                                
run | redb v1 | rocksdb                                                         
-----------------------                                                         
1   | 33s     | 9s                                                              
2   |  4s     | 5s                                                              
                                                                                
                                                                                
testnet stop @100_000 physical disk  NVMe                                           
                                                                                
              | durability       |                                              
run | redb v1 | None |  Eventual | rocksdb                                      
-------------------------------------------                                     
1   | 310s    |  58s |   308s    | 9s                                           
2   | 4s      |   4s |     5s    | 5s                                           
```                      

#63           